### PR TITLE
Fix opening videos with external player

### DIFF
--- a/io.webtorrent.WebTorrent.json
+++ b/io.webtorrent.WebTorrent.json
@@ -29,6 +29,8 @@
         "cp -r usr/* /app",
         "chmod +x /app/bin/webtorrent-desktop",
         "install -m755 webtorrent-wrapper /app/bin",
+        "install -m755 xdg-open-wrapper /app/bin/xdg-open-wrapper",
+        "install -m755 set-external-player /app/bin/set-external-player",
         "install -Dm644 io.webtorrent.WebTorrent.metainfo.xml /app/share/metainfo/io.webtorrent.WebTorrent.metainfo.xml"
       ],
       "post-install": [
@@ -49,7 +51,19 @@
         {
           "type": "script",
           "dest-filename": "webtorrent-wrapper",
-          "commands": ["exec zypak-wrapper /app/bin/webtorrent-desktop \"$@\""]
+          "commands": [
+            "sh /app/bin/set-external-player",
+            "exec zypak-wrapper /app/bin/webtorrent-desktop \"$@\""
+          ]
+        },
+        {
+          "type": "file",
+          "path": "xdg-open-wrapper"
+        },
+        {
+          "type": "file",
+          "path": "set-external-player"
+
         }
       ]
     }

--- a/io.webtorrent.WebTorrent.json
+++ b/io.webtorrent.WebTorrent.json
@@ -1,9 +1,9 @@
 {
   "app-id": "io.webtorrent.WebTorrent",
   "base": "org.electronjs.Electron2.BaseApp",
-  "base-version": "20.08",
+  "base-version": "21.08",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "20.08",
+  "runtime-version": "21.08",
   "sdk": "org.freedesktop.Sdk",
   "command": "webtorrent-wrapper",
   "rename-icon": "webtorrent-desktop",

--- a/set-external-player
+++ b/set-external-player
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+CONFIG_FILE=".var/app/io.webtorrent.WebTorrent/config/WebTorrent/config.json"
+
+if [ -f $CONFIG_FILE ]; then
+    sed 's/"externalPlayerPath": ""/"externalPlayerPath": "\/app\/bin\/xdg-open-wrapper"/g' -i $CONFIG_FILE
+fi
+
+exit

--- a/xdg-open-wrapper
+++ b/xdg-open-wrapper
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+FILE_NAME=$(basename $@ | sed -e's/%\([0-9A-F][0-9A-F]\)/\\\\\x\1/g' | xargs echo -e | sed 's/[^[:alnum:]_-]/\\&/g')
+
+DOWNLOAD_PATH=$(grep "downloadPath" .var/app/io.webtorrent.WebTorrent/config/WebTorrent/config.json | cut -d '"' -f 4)
+
+FILE=$(find $DOWNLOAD_PATH -name "$FILE_NAME" -type f)
+
+xdg-open "$FILE"
+


### PR DESCRIPTION
Attempt to fix #3 

This proposal uses 2 scripts:

- The first is a wrapper that finds the video path from the generated URL then passes it to `xdg-open` to be launched with the host's player. (explained [in the upstream issue](https://github.com/webtorrent/webtorrent-desktop/issues/1533#issuecomment-1013930655))
- The second script silently runs at program startup (for lack of a better solution) and sets the wrapper as the external player when no other value is set.